### PR TITLE
Feature - Channel Cover Photo - Download & Upload to Backblaze B2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ backend/functions/databaseCalls/__pycache__/*
 backend/serviceAccountKey.json
 backend/__pycache__/*
 mongodb/docker-compose.yaml
+backend/*.jpg

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,8 +32,10 @@ While YouTubeDL-Material & TubeArchivist are great projects, I wanted something 
 ## To Do
 
 - [X] [Using Mongo](https://github.com/hxrsmurf/ytdlp-flask-nextjs/pull/13) ~~[Using Firebase](https://github.com/hxrsmurf/ytdlp-flask-nextjs/pull/5)~~ ~~Migrate from SQLite to Serverless Database (DynamoDB, Firestore)~~
-- [ ] Add download functionality to local storage and s3-compatible (BackBlaze B2)
-- [ ] Add CDN functionality via CloudFlare or NGINX to cache videos
+- [ ] - Download functionality and uploade to Backblaze B2 with Cloudflare
+  - [X] [Used for channel cover photos](https://github.com/hxrsmurf/ytdlp-flask-nextjs/pull/15)
+  - [ ] Video thumbnails
+  - [ ] Videos themselves
 - [X] Added basic docker support ~~Dockerize~~
 - [ ] CI/CD (?)
 - [ ] Add badge metrics for issues, license, etc.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 API_url=http://127.0.0.1:5000/
+CDN_URL=https://cdn.example.com
 MONGODB_USER=example
 MONGODB_PASSWORD=example

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -196,3 +196,14 @@ def download_latest():
         completed_videos = get_futures(video_threads)
 
     return(jsonify({'videos_in_range': videos_in_range}, {'completed_videos' : completed_videos}))
+
+@mongo_bp.route('/download/channel/cover/<string:channel_id>', methods=['GET'])
+def download_channel_cover(channel_id):
+    photo_cover_url = json.loads(search_channels(channel_id).data)[0]['picture_cover']
+    photo_cover_request = requests.get(photo_cover_url)
+    photo_cover_output_filename = f'{channel_id}.jpg'
+    if photo_cover_request.status_code == 200:
+        with open(photo_cover_output_filename, 'wb') as file:
+            file.write(photo_cover_request.content)
+
+    return(photo_cover_output_filename)

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -215,7 +215,11 @@ def download_channel_cover(channel_id):
         if photo_cover_request.status_code == 200:
             with open(photo_cover_output_filename, 'wb') as file:
                 file.write(photo_cover_request.content)
+
             b2_upload(file=photo_cover_output_filename, folder=photo_cover_output_folder)
+
+            Mongo.Channels.objects(channel_id=channel_id).update_one(set__cdn_photo_cover=cdn_photo_cover_url)
+
             return(cdn_photo_cover_url)
         else:
             return(photo_cover_url)

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -6,6 +6,7 @@ from flask import Blueprint, jsonify, request
 
 from functions.downloader import download
 from functions.utils import getCurrentTime
+from functions.backblaze_upload import b2_upload
 from classes import Mongo
 
 mongo_bp = Blueprint('mongo', __name__, url_prefix='/mongo')
@@ -205,5 +206,5 @@ def download_channel_cover(channel_id):
     if photo_cover_request.status_code == 200:
         with open(photo_cover_output_filename, 'wb') as file:
             file.write(photo_cover_request.content)
-
+    result = b2_upload(file=photo_cover_output_filename, folder='channel_photo_cover')
     return(photo_cover_output_filename)

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -220,6 +220,9 @@ def download_channel_cover(channel_id):
 
             Mongo.Channels.objects(channel_id=channel_id).update_one(set__cdn_photo_cover=cdn_photo_cover_url)
 
+            if os.path.exists(photo_cover_output_filename):
+                os.remove(photo_cover_output_filename)
+
             return(cdn_photo_cover_url)
         else:
             return(photo_cover_url)

--- a/backend/classes/Mongo.py
+++ b/backend/classes/Mongo.py
@@ -12,6 +12,7 @@ class Channels(mongo_db.Document):
     webpage_url = mongo_db.StringField()
     picture_profile = mongo_db.StringField()
     picture_cover = mongo_db.StringField()
+    cdn_photo_cover = mongo_db.StringField()
     last_updated = mongo_db.StringField()
     latest_upload = mongo_db.StringField()
 

--- a/backend/functions/backblaze_upload.py
+++ b/backend/functions/backblaze_upload.py
@@ -5,20 +5,20 @@ from b2sdk.v2 import *
 
 load_dotenv('../.env')
 
-def b2_upload(file):
+def b2_upload(file, folder):
     B2_BUCKET = os.environ.get("B2_BUCKET")
     B2_KEY_ID = os.environ.get("B2_KEY_ID")
     B2_KEY = os.environ.get("B2_KEY")
 
-    file = '../' + file.replace('\\','/')
-    b2_destination = file.split('../static/')[1]
+    b2_destination = f'{folder}/{file}'
 
     info = InMemoryAccountInfo()
     b2_api = B2Api(info)
     b2_api.authorize_account("production", B2_KEY_ID, B2_KEY)
     bucket = b2_api.get_bucket_by_name(B2_BUCKET)
     print('Uploading to BackBlaze')
-    bucket.upload_local_file(
+    result = bucket.upload_local_file(
             local_file=file,
             file_name=b2_destination
         )
+    return(result)

--- a/frontend/pages/channels.js
+++ b/frontend/pages/channels.js
@@ -20,7 +20,7 @@ export default function channels({ results }) {
                     <Card style={{ width: '75' }} key={id} className='mt-5'>
                         <Card.Header>{result.channel_name} - {result.original_url}</Card.Header>
                         <Card.Img
-                            variant="top" src={result.picture_cover}
+                            variant="top" src={result.cdn_photo_cover}
                             />
                         <Card.ImgOverlay
                             onClick={(e)=> handleClick(result.original_url)}


### PR DESCRIPTION
I want to cache the channels' cover photo instead of getting the data every time. And I believe that's proper internet etiquette to use your bandwidth versus theirs (even if it's Google). 

This downloads the cover photo in binary and uploads to Backblaze B2 via `b2sdk`. I then use Cloudflare for CDN and point to the bucket. (Here's their guide on this.)[https://help.backblaze.com/hc/en-us/articles/217666928-Using-Backblaze-B2-with-the-Cloudflare-CDN]. I had forgotten I wrote some of the Backblaze functionality in https://github.com/hxrsmurf/ytdlp-flask-nextjs/commit/1c9adec0b17da3d5e21b582c14f78df5ba73b63f

I added the new column `cdn_photo_cover` to the Mongo class.

I updated `channels.js` to source the cover photo image from the CDN.

Workflow
1. Get channel cover
2. Download to local disk as `channel_id.jpg`
3. Upload to Backblaze B2
4. Update MongoDB with CDN URL of the photo
5. Delete from local disk