### PR TITLE
Hotfix - Remove trailling slash from download_latest

### DIFF
--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -147,7 +147,7 @@ def videos_sync_channels():
 
     return(jsonify(result_missing))
 
-@mongo_bp.route('/download/latest/', methods=['GET'])
+@mongo_bp.route('/download/latest', methods=['GET'])
 def download_latest():
     channel_id = request.args['id']
     range = int(request.args['range'])


### PR DESCRIPTION
I didn't realize I had a trailing slash in the `download_latest` function in `mongo.py` blueprint. This was causing a cross origin issue. 