### PR TITLE
Feature/limit videosjs

### DIFF
--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -50,9 +50,14 @@ def add_channels():
 
     return(json.loads(query.to_json()))
 
-@mongo_bp.route('/videos/', methods=['GET'])
+@mongo_bp.route('/videos', methods=['GET'])
 def get_videos():
-    query = Mongo.Videos.objects().order_by('-upload_date')
+    if len(request.args) == 0:
+        limit = slice(0,25)
+    else:
+        limit = slice(0,int(request.args['limit']))
+
+    query = Mongo.Videos.objects().order_by('-upload_date')[limit]
     query_json = json.loads(query.to_json())
     return(jsonify(query_json))
 

--- a/frontend/pages/videos.js
+++ b/frontend/pages/videos.js
@@ -156,7 +156,7 @@ export default function videos({ results, result_all_channels }) {
 }
 
 export async function getServerSideProps() {
-    const res = await fetch(process.env.NEXT_PUBLIC_BASE_API_URL + '/mongo/videos/')
+    const res = await fetch(process.env.NEXT_PUBLIC_BASE_API_URL + '/mongo/videos')
     const results = await res.json()
 
     const request_all_channels = await fetch(process.env.NEXT_PUBLIC_BASE_API_URL + '/mongo/videos/unique/channel')


### PR DESCRIPTION
Add a limit on videos.js and the `get_videos()` function in `mongo.py` blueprint as loading all videos wasn't a fun time. 

Included a `limit` parameter for future use. But hard coded `50` for now.