### PR TITLE
Add cdn_photo_cover to Mongo class

### DIFF
--- a/backend/classes/Mongo.py
+++ b/backend/classes/Mongo.py
@@ -15,6 +15,7 @@ class Channels(mongo_db.Document):
     cdn_photo_cover = mongo_db.StringField()
     last_updated = mongo_db.StringField()
     latest_upload = mongo_db.StringField()
+    cdn_photo_cover = mongo_db.StringField()
 
 class Videos(mongo_db.Document):
     channel_name = mongo_db.StringField()


### PR DESCRIPTION
In #15 I had left `cdn_photo_cover` off the Mongo database class. Adding this now. 