### PR TITLE
Move download_channel_cover after database save

### DIFF
--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -30,8 +30,6 @@ def add_channels():
     channel_id = download_result['channel_id']
     channel_name_lowercase = download_result['channel'].lower()
 
-    result_download_cover_photo = download_channel_cover(channel_id)
-
     query = Mongo.Channels(
         channel_id = channel_id,
         channel_name = download_result['channel'],
@@ -45,11 +43,12 @@ def add_channels():
         picture_profile = download_result['thumbnails'][18]['url'],
         picture_cover = download_result['thumbnails'][15]['url'],
         last_updated = getCurrentTime(),
-        latest_upload = download_result['entries'][0]['original_url'],
-        cdn_photo_cover = result_download_cover_photo
+        latest_upload = download_result['entries'][0]['original_url']
     )
 
     query.save()
+
+    download_channel_cover(channel_id)
 
     return(json.loads(query.to_json()))
 


### PR DESCRIPTION
The `download_channel_cover` function searches the channel. But during the `channels/add`, the channel isn't added to the database, so no results from search...so an incorrect result in the `download_channel_cover`. 

I moved the `download_channel_cover` function to after the `query.save()`. 

I can add channels again.