### PR TITLE
Feature - Add Download Video functionality

### DIFF
--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -248,5 +248,6 @@ def download_channel_cover(channel_id):
 def download_video_by_id(video_id):
     query = Mongo.Videos.objects(video_id=video_id)
     query_json = json.loads(query.to_json())[0]
-    print(query_json['original_url'])
-    return(jsonify(query_json))
+    original_url = query_json['original_url']
+    downloaded_file = download(video=original_url, video_range=1, download_confirm=True)
+    return(downloaded_file)

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -250,17 +250,22 @@ def download_video_by_id(video_id):
     query_json = json.loads(query.to_json())[0]
 
     original_url = query_json['original_url']
-    query_cdn_video_url = query_json['cdn_video']
 
     video_file_name = f'{video_id}.mp4'
     video_folder = 'videos'
     cdn_video_url = f'{os.environ.get("CDN_URL")}/{os.environ.get("B2_BUCKET")}/{video_folder}/{video_file_name}'
+
+    try:
+        query_cdn_video_url = query_json['cdn_video']
+        if query_cdn_video_url == cdn_video_url:
+            print('Already uploaded to Backblaze.')
+            return(query_cdn_video_url)
+    except:
+        pass
+
+    print(cdn_video_url)
+
     cdn_video_request = requests.get(cdn_video_url)
-
-    print(query_cdn_video_url)
-
-    if query_cdn_video_url == cdn_video_url:
-        return(query_cdn_video_url)
 
     # If on CDN
     if cdn_video_request.status_code == 200:

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -164,6 +164,12 @@ def videos_sync_channels():
 
     return(jsonify(result_missing))
 
+@mongo_bp.route('/videos/downloaded')
+def videos_already_downloaded():
+    query = Mongo.Videos.objects(cdn_video__contains='https').order_by('-upload_date')
+    query_json = json.loads(query.to_json())
+    return(jsonify(query_json))
+
 @mongo_bp.route('/download/latest', methods=['GET'])
 def download_latest():
     channel_id = request.args['id']

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -243,3 +243,10 @@ def download_channel_cover(channel_id):
             return(cdn_photo_cover_url)
         else:
             return(photo_cover_url)
+
+@mongo_bp.route('/download/video/<string:video_id>', methods=['GET'])
+def download_video_by_id(video_id):
+    query = Mongo.Videos.objects(video_id=video_id)
+    query_json = json.loads(query.to_json())[0]
+    print(query_json['original_url'])
+    return(jsonify(query_json))

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -250,11 +250,17 @@ def download_video_by_id(video_id):
     query_json = json.loads(query.to_json())[0]
 
     original_url = query_json['original_url']
+    query_cdn_video_url = query_json['cdn_video']
 
     video_file_name = f'{video_id}.mp4'
     video_folder = 'videos'
     cdn_video_url = f'{os.environ.get("CDN_URL")}/{os.environ.get("B2_BUCKET")}/{video_folder}/{video_file_name}'
     cdn_video_request = requests.get(cdn_video_url)
+
+    print(query_cdn_video_url)
+
+    if query_cdn_video_url == cdn_video_url:
+        return(query_cdn_video_url)
 
     # If on CDN
     if cdn_video_request.status_code == 200:

--- a/backend/classes/Mongo.py
+++ b/backend/classes/Mongo.py
@@ -33,3 +33,4 @@ class Videos(mongo_db.Document):
     title = mongo_db.StringField()
     upload_date = mongo_db.StringField()
     webpage_url = mongo_db.StringField()
+    cdn_video = mongo_db.StringField()

--- a/backend/functions/backblaze_upload.py
+++ b/backend/functions/backblaze_upload.py
@@ -21,4 +21,5 @@ def b2_upload(file, folder):
             local_file=file,
             file_name=b2_destination
         )
+    print('Successfully uploaded to BackBlaze')
     return(result)

--- a/backend/functions/downloader.py
+++ b/backend/functions/downloader.py
@@ -7,7 +7,7 @@ def download(video, video_range=2, download_confirm=False):
 
     ytdl_opts = {
         #'outtmpl' : 'static/%(uploader)s/%(upload_date>%Y-%m-%d)s_%(id)s_%(title)s.%(ext)s',
-        'outtmpl' : 'static/%(id)s.%(ext)s',
+        'outtmpl' : '%(id)s.%(ext)s',
         'progress_hooks' : [hook],
         #'daterange' : 'today-1year',
         #'download_archive': 'static/downloaded_videos.txt',

--- a/backend/functions/downloader.py
+++ b/backend/functions/downloader.py
@@ -6,7 +6,8 @@ def download(video, video_range=2, download_confirm=False):
                 return(d['filename'])
 
     ytdl_opts = {
-        'outtmpl' : 'static/%(uploader)s/%(upload_date>%Y-%m-%d)s_%(id)s_%(title)s.%(ext)s',
+        #'outtmpl' : 'static/%(uploader)s/%(upload_date>%Y-%m-%d)s_%(id)s_%(title)s.%(ext)s',
+        'outtmpl' : 'static/%(id)s.%(ext)s',
         'progress_hooks' : [hook],
         #'daterange' : 'today-1year',
         #'download_archive': 'static/downloaded_videos.txt',

--- a/frontend/Components/Modals/VideoPlayer.js
+++ b/frontend/Components/Modals/VideoPlayer.js
@@ -1,6 +1,8 @@
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 
+import videojs from 'video.js'
+
 export default function VideoPlayer(props) {
     const title = props.data.title
     const video_url = props.data.cdn_video
@@ -25,7 +27,15 @@ export default function VideoPlayer(props) {
             <Modal.Body>
                 <h4>{channel_name}</h4>
                 <p>
-                    {description}
+                    <video
+                        class='video-js'
+                        controls
+                        preload='auto'
+                        fluid
+                        userActions="{'hotkeys': true}"
+                    >
+                        <source src={video_url} type="video/mp4"/>
+                    </video>
                 </p>
             </Modal.Body>
             <Modal.Footer>

--- a/frontend/Components/Modals/VideoPlayer.js
+++ b/frontend/Components/Modals/VideoPlayer.js
@@ -1,7 +1,7 @@
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
-
-import videojs from 'video.js'
+import Container from 'react-bootstrap/Container';
+import { Dot, HandThumbsUp } from 'react-bootstrap-icons';
 
 export default function VideoPlayer(props) {
     const title = props.data.title
@@ -15,9 +15,8 @@ export default function VideoPlayer(props) {
     return (
         <Modal
             {...props}
-            size="lg"
             aria-labelledby="contained-modal-title-vcenter"
-            centered
+            fullscreen
         >
             <Modal.Header closeButton>
                 <Modal.Title id="contained-modal-title-vcenter">
@@ -26,19 +25,20 @@ export default function VideoPlayer(props) {
             </Modal.Header>
             <Modal.Body>
                 <h4>{channel_name}</h4>
-                <p>
+                <Container>
                     <video
-                        class='video-js'
                         controls
                         preload='auto'
-                        fluid
-                        userActions="{'hotkeys': true}"
-                    >
+                        userActions='{"hotkeys": true}'
+                        width='1024px'
+                        height='640px'
+                        >
                         <source src={video_url} type="video/mp4"/>
                     </video>
-                </p>
+                </Container>
             </Modal.Body>
             <Modal.Footer>
+                <HandThumbsUp/> {like_count}<Dot/>{view_count} views
                 <Button onClick={props.onHide}>Close</Button>
             </Modal.Footer>
         </Modal>

--- a/frontend/Components/Modals/VideoPlayer.js
+++ b/frontend/Components/Modals/VideoPlayer.js
@@ -1,0 +1,36 @@
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+
+export default function VideoPlayer(props) {
+    const title = props.data.title
+    const video_url = props.data.cdn_video
+    const channel_name = props.data.channel_name
+    const like_count = props.data.like_count
+    const upload_date = props.data.upload_date
+    const view_count = props.data.view_count
+    const description = props.data.description
+
+    return (
+        <Modal
+            {...props}
+            size="lg"
+            aria-labelledby="contained-modal-title-vcenter"
+            centered
+        >
+            <Modal.Header closeButton>
+                <Modal.Title id="contained-modal-title-vcenter">
+                    {title}
+                </Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <h4>{channel_name}</h4>
+                <p>
+                    {description}
+                </p>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button onClick={props.onHide}>Close</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/frontend/Components/VideoCardList.js
+++ b/frontend/Components/VideoCardList.js
@@ -10,6 +10,10 @@ export default function VideoCardList({ data }) {
         window.open(event, '_blank')
     }
 
+    const handleDownloadClick = async (event) => {
+        console.log(event)
+    }
+
     return (
         <>
             <Row style={{ height: '150px' }}>
@@ -40,7 +44,9 @@ export default function VideoCardList({ data }) {
                                                 </Col>
                                                 <Col md='auto'>
                                                     <Button
-                                                        variant='secondary'>
+                                                        variant='secondary'
+                                                        onMouseDown={() => handleDownloadClick(result._id)}
+                                                        >
                                                         <Download size={20} />
                                                     </Button>
                                                 </Col>

--- a/frontend/Components/VideoCardList.js
+++ b/frontend/Components/VideoCardList.js
@@ -2,7 +2,7 @@ import Card from 'react-bootstrap/Card'
 import Row from 'react-bootstrap/Row'
 import Button from 'react-bootstrap/Button'
 import Col from 'react-bootstrap/Col'
-import { Youtube, Download, HandThumbsUp, Dot } from 'react-bootstrap-icons'
+import { Youtube, Download, HandThumbsUp, Dot, PlayFill } from 'react-bootstrap-icons'
 
 export default function VideoCardList({ data }) {
 
@@ -13,6 +13,10 @@ export default function VideoCardList({ data }) {
     const handleDownloadClick = async (event) => {
         const query_url = (process.env.NEXT_PUBLIC_BASE_API_URL + '/mongo/download/video/' + event)
         fetch(query_url)
+    }
+
+    const handlePlayCDNVideo = async (event) => {
+        console.log(event)
     }
 
     return (
@@ -44,12 +48,24 @@ export default function VideoCardList({ data }) {
                                                     </Button>
                                                 </Col>
                                                 <Col md='auto'>
-                                                    <Button
-                                                        variant='secondary'
-                                                        onMouseDown={() => handleDownloadClick(result._id)}
-                                                        >
-                                                        <Download size={20} />
-                                                    </Button>
+                                                    {result.cdn_video ?
+                                                        <>
+                                                            <Button
+                                                                variant='outline-secondary'
+                                                                onMouseDown={() => handlePlayCDNVideo(result.cdn_video)}
+                                                            >
+                                                                <PlayFill size={20} />
+                                                            </Button>
+                                                        </>
+                                                        :
+                                                        <>
+                                                            <Button
+                                                                variant='outline-secondary'
+                                                                onMouseDown={() => handleDownloadClick(result._id)}
+                                                            >
+                                                                <Download size={20} />
+                                                            </Button>
+                                                        </>}
                                                 </Col>
                                             </Row>
                                         </div>

--- a/frontend/Components/VideoCardList.js
+++ b/frontend/Components/VideoCardList.js
@@ -62,7 +62,7 @@ export default function VideoCardList({ data }) {
                                                             >
                                                                 <PlayFill size={20} />
                                                             </Button>
-                                                            <VideoPlayer show={modalShow} data={cdnVideo} onHide={() => setModalShow(false)}/>
+                                                            {cdnVideo ? <><VideoPlayer show={modalShow} data={cdnVideo} onHide={() => setModalShow(false)}/></> : <></>}
                                                         </>
                                                         :
                                                         <>

--- a/frontend/Components/VideoCardList.js
+++ b/frontend/Components/VideoCardList.js
@@ -3,8 +3,12 @@ import Row from 'react-bootstrap/Row'
 import Button from 'react-bootstrap/Button'
 import Col from 'react-bootstrap/Col'
 import { Youtube, Download, HandThumbsUp, Dot, PlayFill } from 'react-bootstrap-icons'
+import VideoPlayer from './Modals/VideoPlayer'
+import { useState } from 'react'
 
 export default function VideoCardList({ data }) {
+    const [cdnVideo, setCDNVideo] = useState()
+    const [modalShow, setModalShow] = useState()
 
     const handleClick = async (event) => {
         window.open(event, '_blank')
@@ -17,6 +21,8 @@ export default function VideoCardList({ data }) {
 
     const handlePlayCDNVideo = async (event) => {
         console.log(event)
+        setCDNVideo(event)
+        setModalShow(true)
     }
 
     return (
@@ -52,10 +58,11 @@ export default function VideoCardList({ data }) {
                                                         <>
                                                             <Button
                                                                 variant='outline-secondary'
-                                                                onMouseDown={() => handlePlayCDNVideo(result.cdn_video)}
+                                                                onMouseDown={() => handlePlayCDNVideo(result)}
                                                             >
                                                                 <PlayFill size={20} />
                                                             </Button>
+                                                            <VideoPlayer show={modalShow} data={cdnVideo} onHide={() => setModalShow(false)}/>
                                                         </>
                                                         :
                                                         <>

--- a/frontend/Components/VideoCardList.js
+++ b/frontend/Components/VideoCardList.js
@@ -11,7 +11,8 @@ export default function VideoCardList({ data }) {
     }
 
     const handleDownloadClick = async (event) => {
-        console.log(event)
+        const query_url = (process.env.NEXT_PUBLIC_BASE_API_URL + '/mongo/download/video/' + event)
+        fetch(query_url)
     }
 
     return (

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "react": "18.2.0",
         "react-bootstrap": "^2.4.0",
         "react-bootstrap-icons": "^1.8.4",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "video.js": "^7.20.1"
       },
       "devDependencies": {
         "eslint": "8.19.0",
@@ -533,6 +534,60 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@videojs/http-streaming": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.14.2.tgz",
+      "integrity": "sha512-K1raSfO/pq5r8iUas3OSYni0kXOj91n8ealIpV02khghzGv9LQ6O3YUqYd/eAhJ1HIrmZWOnrYpK/P+mhUExXQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "3.0.5",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "m3u8-parser": "4.7.1",
+        "mpd-parser": "0.21.1",
+        "mux.js": "6.0.1",
+        "video.js": "^6 || ^7"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "video.js": "^6 || ^7"
+      }
+    },
+    "node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "node_modules/@videojs/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
@@ -552,6 +607,17 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/aes-decrypter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.3.tgz",
+      "integrity": "sha512-VkG9g4BbhMBy+N5/XodDeV6F02chEk9IpgRTq/0bS80y4dzy79VH2Gtms02VXomf3HmyRe3yyJYkJ990ns+d6A==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
       }
     },
     "node_modules/ajv": {
@@ -935,6 +1001,11 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -1666,6 +1737,15 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "node_modules/globals": {
       "version": "13.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
@@ -1804,6 +1884,11 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/individual": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
+      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g=="
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1917,6 +2002,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
@@ -2096,6 +2186,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -2166,6 +2261,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/m3u8-parser": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.7.1.tgz",
+      "integrity": "sha512-pbrQwiMiq+MmI9bl7UjtPT3AK603PV9bogNlr83uC+X9IoxqL5E4k7kU7fMQ0dpRgxgeSMygqUa0IMLQNXLBNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2188,6 +2293,14 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2206,11 +2319,41 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "node_modules/mpd-parser": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.21.1.tgz",
+      "integrity": "sha512-BxlSXWbKE1n7eyEPBnTEkrzhS3PdmkkKdM1pgKbPnPOH0WFZIc0sPOWi7m0Uo3Wd2a4Or8Qf4ZbS7+ASqQ49fw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "@xmldom/xmldom": "^0.7.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "mpd-to-m3u8-json": "bin/parse.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/mux.js": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
+      "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "muxjs-transmux": "bin/transmux.js"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -2516,6 +2659,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkcs7": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
+      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5"
+      },
+      "bin": {
+        "pkcs7": "bin/cli.js"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
@@ -2540,6 +2694,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prop-types": {
@@ -2787,6 +2949,22 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rust-result": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
+      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
+      "dependencies": {
+        "individual": "^2.0.0"
+      }
+    },
+    "node_modules/safe-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
+      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
+      "dependencies": {
+        "rust-result": "^1.0.0"
       }
     },
     "node_modules/scheduler": {
@@ -3119,6 +3297,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-toolkit": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
@@ -3132,6 +3315,39 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/video.js": {
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.20.1.tgz",
+      "integrity": "sha512-QMuj+bjwvLId9SY8uBAjO9sw7pCDhdVzJtwsAwg1MdVLXgVuxhhSYswdsdsRk+YMssHtReopINclvDlTGTxMLA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/http-streaming": "2.14.2",
+        "@videojs/vhs-utils": "^3.0.4",
+        "@videojs/xhr": "2.6.0",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "keycode": "^2.2.0",
+        "m3u8-parser": "4.7.1",
+        "mpd-parser": "0.21.1",
+        "mux.js": "6.0.1",
+        "safe-json-parse": "4.0.0",
+        "videojs-font": "3.2.0",
+        "videojs-vtt.js": "^0.15.3"
+      }
+    },
+    "node_modules/videojs-font": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
+      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
+    },
+    "node_modules/videojs-vtt.js": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.3.tgz",
+      "integrity": "sha512-5FvVsICuMRx6Hd7H/Y9s9GDeEtYcXQWzGMS+sl4UX3t/zoHp3y+isSfIPRochnTH7h+Bh1ILyC639xy9Z6kPag==",
+      "dependencies": {
+        "global": "^4.3.1"
+      }
     },
     "node_modules/warning": {
       "version": "4.0.3",
@@ -3508,6 +3724,46 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@videojs/http-streaming": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.14.2.tgz",
+      "integrity": "sha512-K1raSfO/pq5r8iUas3OSYni0kXOj91n8ealIpV02khghzGv9LQ6O3YUqYd/eAhJ1HIrmZWOnrYpK/P+mhUExXQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "3.0.5",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "m3u8-parser": "4.7.1",
+        "mpd-parser": "0.21.1",
+        "mux.js": "6.0.1",
+        "video.js": "^6 || ^7"
+      }
+    },
+    "@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      }
+    },
+    "@videojs/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
+    },
     "acorn": {
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
@@ -3520,6 +3776,17 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "aes-decrypter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.3.tgz",
+      "integrity": "sha512-VkG9g4BbhMBy+N5/XodDeV6F02chEk9IpgRTq/0bS80y4dzy79VH2Gtms02VXomf3HmyRe3yyJYkJ990ns+d6A==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -3797,6 +4064,11 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -4373,6 +4645,15 @@
         "is-glob": "^4.0.3"
       }
     },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "globals": {
       "version": "13.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
@@ -4463,6 +4744,11 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
+    "individual": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
+      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4546,6 +4832,11 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
+    },
+    "is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-glob": {
       "version": "4.0.3",
@@ -4674,6 +4965,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
+    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -4732,6 +5028,16 @@
         "yallist": "^4.0.0"
       }
     },
+    "m3u8-parser": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.7.1.tgz",
+      "integrity": "sha512-pbrQwiMiq+MmI9bl7UjtPT3AK603PV9bogNlr83uC+X9IoxqL5E4k7kU7fMQ0dpRgxgeSMygqUa0IMLQNXLBNA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      }
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4746,6 +5052,14 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "requires": {
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -4763,11 +5077,31 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "mpd-parser": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.21.1.tgz",
+      "integrity": "sha512-BxlSXWbKE1n7eyEPBnTEkrzhS3PdmkkKdM1pgKbPnPOH0WFZIc0sPOWi7m0Uo3Wd2a4Or8Qf4ZbS7+ASqQ49fw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "@xmldom/xmldom": "^0.7.2",
+        "global": "^4.4.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "mux.js": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
+      "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -4975,6 +5309,14 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pkcs7": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
+      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5"
+      }
+    },
     "postcss": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
@@ -4990,6 +5332,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "prop-types": {
       "version": "15.8.1",
@@ -5148,6 +5495,22 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rust-result": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
+      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
+      "requires": {
+        "individual": "^2.0.0"
+      }
+    },
+    "safe-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
+      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
+      "requires": {
+        "rust-result": "^1.0.0"
       }
     },
     "scheduler": {
@@ -5387,6 +5750,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-toolkit": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
+    },
     "use-sync-external-store": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
@@ -5398,6 +5766,39 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "video.js": {
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.20.1.tgz",
+      "integrity": "sha512-QMuj+bjwvLId9SY8uBAjO9sw7pCDhdVzJtwsAwg1MdVLXgVuxhhSYswdsdsRk+YMssHtReopINclvDlTGTxMLA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/http-streaming": "2.14.2",
+        "@videojs/vhs-utils": "^3.0.4",
+        "@videojs/xhr": "2.6.0",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "keycode": "^2.2.0",
+        "m3u8-parser": "4.7.1",
+        "mpd-parser": "0.21.1",
+        "mux.js": "6.0.1",
+        "safe-json-parse": "4.0.0",
+        "videojs-font": "3.2.0",
+        "videojs-vtt.js": "^0.15.3"
+      }
+    },
+    "videojs-font": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
+      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
+    },
+    "videojs-vtt.js": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.3.tgz",
+      "integrity": "sha512-5FvVsICuMRx6Hd7H/Y9s9GDeEtYcXQWzGMS+sl4UX3t/zoHp3y+isSfIPRochnTH7h+Bh1ILyC639xy9Z6kPag==",
+      "requires": {
+        "global": "^4.3.1"
+      }
     },
     "warning": {
       "version": "4.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "react": "18.2.0",
     "react-bootstrap": "^2.4.0",
     "react-bootstrap-icons": "^1.8.4",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "video.js": "^7.20.1"
   },
   "devDependencies": {
     "eslint": "8.19.0",

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,5 +1,6 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Navigation from "../Components/Navigation"
+import 'video.js/dist/video-js.min.css'
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/frontend/pages/videos.js
+++ b/frontend/pages/videos.js
@@ -54,6 +54,12 @@ export default function videos({ results, result_all_channels }) {
         setTimeout(() => setLoading(false), 1000);
     }
 
+    const handleShowDownloadedVideos = async (event) => {
+        const request = await fetch(base_api_url + '/mongo/videos/downloaded')
+        const results = await request.json()
+        setNewResults(results)
+    }
+
     return (
         <>
             <Container className='mt-5'>
@@ -105,6 +111,13 @@ export default function videos({ results, result_all_channels }) {
                             onMouseDown={(e) => handleResetFilter(e)}
                         >
                             Reset</Button>
+                    </Col>
+                    <Col md='auto'>
+                        <Button
+                            variant='info'
+                            onMouseDown={(e) => handleShowDownloadedVideos(e)}
+                        >
+                            Show Downloaded</Button>
                     </Col>
                     <Col md='auto'>
                         {loading ? <LoadingCircle text='Downloading...' />


### PR DESCRIPTION
This adds a basic download button to the video card. 

The video is downloaded, uploaded to Backblaze, and updates the video entry's database entry with the CDN URL. 

CDN (CloudFlare) eventually sees the file and we can play that from CloudFlare versus YouTube. 

I also added a `Show Downloaded` filter to view the ones that are downloaded.