### PR TITLE
Feature/watched button

### DIFF
--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -192,13 +192,15 @@ def videos_mark_unwatched(video_id):
 
 @mongo_bp.route('/videos/watched')
 def videos_view_watched():
-    query = Mongo.Videos.objects(watched=True).order_by('-upload_date')
+    limit = slice(0,25)
+    query = Mongo.Videos.objects(watched=True).order_by('-upload_date')[limit]
     query_json = json.loads(query.to_json())
     return(jsonify(query_json))
 
 @mongo_bp.route('/videos/unwatched')
 def videos_view_unwatched():
-    query = Mongo.Videos.objects(watched=False).order_by('-upload_date')
+    limit = slice(0,25)
+    query = Mongo.Videos.objects(watched__ne=True).order_by('-upload_date')[limit]
     query_json = json.loads(query.to_json())
     return(jsonify(query_json))
 

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -104,7 +104,8 @@ def add_videos():
         thumbnail = download_result['thumbnail'],
         title = download_result['title'],
         upload_date = download_result['upload_date'],
-        webpage_url = download_result['webpage_url']
+        webpage_url = download_result['webpage_url'],
+        watched = False
     )
 
     query.save()

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -189,6 +189,18 @@ def videos_mark_unwatched(video_id):
         print('Error')
         return Response('Error', status=500)
 
+@mongo_bp.route('/videos/watched')
+def videos_view_watched():
+    query = Mongo.Videos.objects(watched=True).order_by('-upload_date')
+    query_json = json.loads(query.to_json())
+    return(jsonify(query_json))
+
+@mongo_bp.route('/videos/unwatched')
+def videos_view_unwatched():
+    query = Mongo.Videos.objects(watched=False).order_by('-upload_date')
+    query_json = json.loads(query.to_json())
+    return(jsonify(query_json))
+
 @mongo_bp.route('/download/latest', methods=['GET'])
 def download_latest():
     channel_id = request.args['id']

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -170,10 +170,20 @@ def videos_already_downloaded():
     query_json = json.loads(query.to_json())
     return(jsonify(query_json))
 
+# Could probably boolean the watched URL, but opting to do this for now.
 @mongo_bp.route('/videos/<string:video_id>/watched')
 def videos_mark_watched(video_id):
     try:
         Mongo.Videos.objects(video_id=video_id).update_one(watched=True)
+        return('Success')
+    except:
+        print('Error')
+        return Response('Error', status=500)
+
+@mongo_bp.route('/videos/<string:video_id>/unwatched')
+def videos_mark_unwatched(video_id):
+    try:
+        Mongo.Videos.objects(video_id=video_id).update_one(watched=False)
         return('Success')
     except:
         print('Error')

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -2,7 +2,7 @@ import json
 import os
 import requests
 import concurrent.futures
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, Response
 
 from functions.downloader import download
 from functions.utils import getCurrentTime
@@ -169,6 +169,15 @@ def videos_already_downloaded():
     query = Mongo.Videos.objects(cdn_video__contains='https').order_by('-upload_date')
     query_json = json.loads(query.to_json())
     return(jsonify(query_json))
+
+@mongo_bp.route('/videos/<string:video_id>/watched')
+def videos_mark_watched(video_id):
+    try:
+        Mongo.Videos.objects(video_id=video_id).update_one(watched=True)
+        return('Success')
+    except:
+        print('Error')
+        return Response('Error', status=500)
 
 @mongo_bp.route('/download/latest', methods=['GET'])
 def download_latest():

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -165,6 +165,22 @@ def videos_sync_channels():
 
     return(jsonify(result_missing))
 
+@mongo_bp.route('/videos/sync/watched')
+def videos_sync_watched():
+    # This was a one-time deal to update the database.
+    # query = Mongo.Videos.objects(watched__ne='True').order_by('-upload_date')
+
+    query = Mongo.Videos.objects(watched='').order_by('-upload_date')
+    query_json = json.loads(query.to_json())
+
+    try:
+        for q in query_json:
+            print(q)
+            videos_mark_unwatched(q['_id'])
+        return('Success')
+    except Exception as e:
+        return(f'Error because {e}')
+
 @mongo_bp.route('/videos/downloaded')
 def videos_already_downloaded():
     query = Mongo.Videos.objects(cdn_video__contains='https').order_by('-upload_date')

--- a/backend/classes/Mongo.py
+++ b/backend/classes/Mongo.py
@@ -34,3 +34,4 @@ class Videos(mongo_db.Document):
     upload_date = mongo_db.StringField()
     webpage_url = mongo_db.StringField()
     cdn_video = mongo_db.StringField()
+    watched = mongo_db.BooleanField()

--- a/frontend/Components/VideoButtons.js
+++ b/frontend/Components/VideoButtons.js
@@ -32,6 +32,11 @@ export default function VideoButtons(props) {
         const result =  await fetch(query_url)
     }
 
+    const handleUnwatchedClick = async (event) => {
+        const query_url = (process.env.NEXT_PUBLIC_BASE_API_URL + '/mongo/videos/' + event + '/unwatched')
+        const result =  await fetch(query_url)
+    }
+
     return (
         <>
             <div className='mt-4'>
@@ -75,7 +80,10 @@ export default function VideoButtons(props) {
                     <Col md='auto'>
                         {result.watched ?
                         <>
-                            <Button variant='outline-secondary'>
+                            <Button
+                                variant='outline-secondary'
+                                onMouseDown={() => handleUnwatchedClick(result._id)}
+                            >
                                 <DisplayFill size={15}/>
                             </Button>
                         </>

--- a/frontend/Components/VideoButtons.js
+++ b/frontend/Components/VideoButtons.js
@@ -27,6 +27,11 @@ export default function VideoButtons(props) {
         setModalShow(true)
     }
 
+    const handleWatchedClick = async (event) => {
+        const query_url = (process.env.NEXT_PUBLIC_BASE_API_URL + '/mongo/videos/' + event + '/watched')
+        const result =  await fetch(query_url)
+    }
+
     return (
         <>
             <div className='mt-4'>
@@ -76,7 +81,10 @@ export default function VideoButtons(props) {
                         </>
                         :
                         <>
-                            <Button variant='outline-secondary'>
+                            <Button
+                                variant='outline-secondary'
+                                onMouseDown={() => handleWatchedClick(result._id)}
+                            >
                                 <Display size={15}/>
                             </Button>
                         </>

--- a/frontend/Components/VideoButtons.js
+++ b/frontend/Components/VideoButtons.js
@@ -1,4 +1,4 @@
-import { Youtube, Download, PlayFill } from 'react-bootstrap-icons'
+import { Youtube, Download, PlayFill, Display, DisplayFill } from 'react-bootstrap-icons'
 import { useState } from 'react'
 
 import Row from 'react-bootstrap/Row'
@@ -36,7 +36,7 @@ export default function VideoButtons(props) {
                             href={result.original_url}
                             target="_blank"
                             variant='outline-danger'>
-                            <Youtube size={20} />
+                            <Youtube size={15} />
                         </Button>
                     </Col>
                     <Col md='auto'>
@@ -46,7 +46,7 @@ export default function VideoButtons(props) {
                                     variant='outline-secondary'
                                     onMouseDown={() => handlePlayCDNVideo(result)}
                                 >
-                                    <PlayFill size={20} />
+                                    <PlayFill size={15} />
                                 </Button>
                                 {
                                     cdnVideo ?
@@ -63,9 +63,24 @@ export default function VideoButtons(props) {
                                     variant='outline-secondary'
                                     onMouseDown={() => handleDownloadClick(result._id)}
                                 >
-                                    <Download size={20} />
+                                    <Download size={15} />
                                 </Button>
                             </>}
+                    </Col>
+                    <Col md='auto'>
+                        {result.watched ?
+                        <>
+                            <Button variant='outline-secondary'>
+                                <DisplayFill size={15}/>
+                            </Button>
+                        </>
+                        :
+                        <>
+                            <Button variant='outline-secondary'>
+                                <Display size={15}/>
+                            </Button>
+                        </>
+                        }
                     </Col>
                 </Row>
             </div>

--- a/frontend/pages/videos.js
+++ b/frontend/pages/videos.js
@@ -20,6 +20,7 @@ export default function videos({ results, result_all_channels }) {
     const [newResults, setNewResults] = useState()
     const [loading, setLoading] = useState()
     const [missingChannels, setMissingChannels] = useState()
+    const [showWatchedButton, setShowWatchedButton] = useState()
 
     const base_api_url = process.env.NEXT_PUBLIC_BASE_API_URL
 
@@ -57,6 +58,20 @@ export default function videos({ results, result_all_channels }) {
     const handleShowDownloadedVideos = async (event) => {
         const request = await fetch(base_api_url + '/mongo/videos/downloaded')
         const results = await request.json()
+        setNewResults(results)
+    }
+
+    const handleShowWatched = async (event) => {
+        const request = await fetch(base_api_url + '/mongo/videos/watched')
+        const results = await request.json()
+        setShowWatchedButton(false)
+        setNewResults(results)
+    }
+
+    const handleShowUnWatched = async (event) => {
+        const request = await fetch(base_api_url + '/mongo/videos/unwatched')
+        const results = await request.json()
+        setShowWatchedButton(true)
         setNewResults(results)
     }
 
@@ -118,6 +133,28 @@ export default function videos({ results, result_all_channels }) {
                             onMouseDown={(e) => handleShowDownloadedVideos(e)}
                         >
                             Show Downloaded</Button>
+                    </Col>
+                    <Col md='auto'>
+                        {showWatchedButton ?
+                        <>
+                            <Button
+                                variant='secondary'
+                                onMouseDown={(e) => handleShowWatched(e)}
+                            >
+                                Show Watched
+                            </Button>
+                        </>
+                        :
+                        <>
+                            <Button
+                                variant='secondary'
+                                onMouseDown={(e) => handleShowUnWatched(e)}
+                            >
+                                Show Unwatched
+                            </Button>
+                        </>
+                        }
+
                     </Col>
                     <Col md='auto'>
                         {loading ? <LoadingCircle text='Downloading...' />


### PR DESCRIPTION
I wanted to be able to filter out the watched videos from the "homepage." 

I added a simple `watched` button. I couldn't decide on which one, so I thought the [Display](https://icons.getbootstrap.com/icons/display/) and [DisplayFill](https://icons.getbootstrap.com/icons/display/) BootStrap Icons were good enough. 

- Add watch/unwatch filter button with appropriate handles
- Add `watched` = `false` when adding a new video
- Add limit during filter
- Add a temporary `videos_sync_watched` function to update database

There's a bug where clicking watch/unwatch doesn't refresh the state. I think I have to `useEffect` that or pass a state from `videos.js`. That'll be a fix it later. Created this to to track it https://github.com/hxrsmurf/ytdlp-flask-nextjs/issues/29