### PR TITLE
Feature/cron mongobackup b2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ backend/*.jpg
 alpine-cron/cronjobs
 mongodb/data/*
 alpine-cron/credentials.txt
+alpine-cron/backup.sh
+alpine-cron/docker-compose.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ backend/__pycache__/*
 mongodb/docker-compose.yaml
 backend/*.jpg
 alpine-cron/cronjobs
+mongodb/data/*
+alpine-cron/credentials.txt

--- a/alpine-cron/Dockerfile
+++ b/alpine-cron/Dockerfile
@@ -1,6 +1,11 @@
-FROM alpine:latest
+FROM python:alpine
 
-RUN apk add --no-cache curl
+ARG B2_KEY_ID=
+ARG B2_APPLICATION_KEY=
+
+RUN apk add --no-cache curl mongodb-tools
+RUN pip install b2
+run b2 authorize-account ${B2_KEY_ID} ${B2_APPLICATION_KEY}
 COPY cronjobs /etc/crontabs/root
 
 CMD ["crond", "-f", "-d", "8"]

--- a/alpine-cron/Dockerfile
+++ b/alpine-cron/Dockerfile
@@ -2,6 +2,7 @@ FROM python:alpine AS builder
 
 RUN apk add --no-cache curl mongodb-tools py3-pip
 RUN pip install b2
+RUN mkdir /tmp/backups
 
 FROM builder
 
@@ -10,7 +11,10 @@ ARG B2_APPLICATION_KEY
 ENV B2_APPLICATION_KEY_ID=${B2_APPLICATION_KEY_ID}
 ENV B2_APPLICATION_KEY=${B2_APPLICATION_KEY}
 
-RUN b2 authorize-account $B2_APPLICATION_KEY_ID $B2_APPLICATION_KEY
 COPY cronjobs /etc/crontabs/root
+COPY backup.sh /root/backup.sh
+
+RUN b2 authorize-account $B2_APPLICATION_KEY_ID $B2_APPLICATION_KEY
+RUN chmod +x /root/backup.sh
 
 CMD ["crond", "-f", "-d", "8"]

--- a/alpine-cron/Dockerfile
+++ b/alpine-cron/Dockerfile
@@ -1,4 +1,9 @@
-FROM hxrsmurf/python-alpine-b2
+FROM python:alpine AS builder
+
+RUN apk add --no-cache curl mongodb-tools py3-pip
+RUN pip install b2
+
+FROM builder
 
 ARG B2_APPLICATION_KEY_ID
 ARG B2_APPLICATION_KEY

--- a/alpine-cron/Dockerfile
+++ b/alpine-cron/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:alpine
+FROM hxrsmurf/python-alpine-b2
 
-ARG B2_KEY_ID=
-ARG B2_APPLICATION_KEY=
+ARG B2_APPLICATION_KEY_ID
+ARG B2_APPLICATION_KEY
+ENV B2_APPLICATION_KEY_ID=${B2_APPLICATION_KEY_ID}
+ENV B2_APPLICATION_KEY=${B2_APPLICATION_KEY}
 
-RUN apk add --no-cache curl mongodb-tools
-RUN pip install b2
-run b2 authorize-account ${B2_KEY_ID} ${B2_APPLICATION_KEY}
+RUN b2 authorize-account $B2_APPLICATION_KEY_ID $B2_APPLICATION_KEY
 COPY cronjobs /etc/crontabs/root
 
 CMD ["crond", "-f", "-d", "8"]

--- a/alpine-cron/ReadMe.md
+++ b/alpine-cron/ReadMe.md
@@ -1,0 +1,8 @@
+# Welcome
+
+This is a basic docker container to run `cron` in alpine.
+
+I've got it doing a few things every 4-hours:
+
+- Query my `latest` API to get the latest YouTube videos
+- Backup the MongoDB with [mongodump](https://www.mongodb.com/docs/database-tools/mongodump/) and upload to [Backblaze B2](https://www.backblaze.com/b2/docs/quick_command_line.html)

--- a/alpine-cron/backup.sh.example
+++ b/alpine-cron/backup.sh.example
@@ -1,0 +1,4 @@
+#!/bin/sh
+mongodump --host=serverip --db=ytdlp --username=user --password=pass --authenticationDatabase=admin  --archive> /tmp/backups/$(date +%Y%m%d-%H%M%S-UTC).archive
+b2 sync /tmp/backups b2://bucket
+rm /tmp/backups/*

--- a/alpine-cron/cronjobs.example
+++ b/alpine-cron/cronjobs.example
@@ -1,2 +1,3 @@
-0 0 * * * curl -L https://api.youtube.com/mongo/download/latest?range=1\&id=all >/dev/null
-##
+0 0/4 * * * curl -L https://api.youtube.com/mongo/download/latest?range=1\&id=all > /dev/null
+0 0/4 * * * * /root/backup.sh > /dev/null
+#

--- a/alpine-cron/docker-compose.yaml
+++ b/alpine-cron/docker-compose.yaml
@@ -3,3 +3,6 @@ services:
   cron:
     build:
       context: .
+      args:
+        - B2_APPLICATION_KEY_ID=
+        - B2_APPLICATION_KEY=

--- a/alpine-cron/docker-compose.yaml.example
+++ b/alpine-cron/docker-compose.yaml.example
@@ -1,0 +1,8 @@
+version: '3.3'
+services:
+  cron:
+    build:
+      context: .
+      args:
+        - B2_APPLICATION_KEY_ID=
+        - B2_APPLICATION_KEY=


### PR DESCRIPTION
I yeeted my MongoDB a few hours ago and I couldn't figure out how to restore it from `/var/lib/docker/volumes`. 

So, I added to the `alpine-cron` `Dockerfile` a way to backup via `mongodump` and `b2`. 