### PR TITLE
Feature - Channel Cover Photo - Use NextJS Image Optimization

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: { domains: ['cdn']}
 }
 
 module.exports = nextConfig

--- a/frontend/pages/channels.js
+++ b/frontend/pages/channels.js
@@ -2,10 +2,15 @@ import Container from 'react-bootstrap/Container'
 import EntryForm from '../Components/EntryForm'
 import Card from 'react-bootstrap/Card'
 
+import Image from 'next/image'
+import { useRef } from 'react'
+
 export default function channels({ results }) {
     const handleClick = async (event) => {
         window.open(event, '_blank')
     }
+
+    const lazyRoot = useRef(null)
 
     return (
         <>
@@ -15,17 +20,25 @@ export default function channels({ results }) {
                 </Container>
             </Container>
 
-            <Container className='mt-5'>
+            <Container className='mt-5' >
                 {results.map((result, id) => (
-                    <Card style={{ width: '75' }} key={id} className='mt-5'>
-                        <Card.Header>{result.channel_name} - {result.original_url}</Card.Header>
-                        <Card.Img
-                            variant="top" src={result.cdn_photo_cover}
-                            />
-                        <Card.ImgOverlay
+                    <Card style={{ width: '75', cursor: 'pointer' }} key={id} className='mt-5'
                             onClick={(e)=> handleClick(result.original_url)}
-                            style={{ cursor: "pointer" }}
-                        />
+                            >
+                        <Card.Header>{result.channel_name} - {result.original_url}</Card.Header>
+                        <Card.Body>
+                            {result.cdn_photo_cover ?
+                                <Image
+                                    src={result.cdn_photo_cover}
+                                    width={100}
+                                    height={20}
+                                    layout='responsive'
+                                    lazyBoundary='25px'
+                                    quality={100}/>
+                            :
+                                <></>
+                            }
+                        </Card.Body>
                         <Card.Footer className="text-muted">{result.description}</Card.Footer>
 
                     </Card>


### PR DESCRIPTION
The `channels` page loaded all images, for every channel. It appears [NextJS Images](https://nextjs.org/docs/basic-features/image-optimization) can lazy load so I tested that out.

~1.4s to load and now ~800ms. Not bad!

I attempted to make the `ViewPort` small so not everything is loading.