### PR TITLE
Hotfix/rel noopener #41

### DIFF
--- a/frontend/Components/VideoButtons.js
+++ b/frontend/Components/VideoButtons.js
@@ -52,7 +52,7 @@ export default function VideoButtons(props) {
                         {result.cdn_video ?
                             <>
                                 <Col md='auto'>
-                                    <a href={result.cdn_video} download target="_blank" rel='noreferrer'>
+                                    <a href={result.cdn_video} download target="_blank" rel='noreferrer noopener'>
                                         <Button
                                             variant='outline-secondary'
                                             onMouseDown={() => handleDownloadLocal(result)}

--- a/frontend/Components/VideoButtons.js
+++ b/frontend/Components/VideoButtons.js
@@ -52,7 +52,7 @@ export default function VideoButtons(props) {
                         {result.cdn_video ?
                             <>
                                 <Col md='auto'>
-                                    <a href={result.cdn_video} download target="_blank">
+                                    <a href={result.cdn_video} download target="_blank" rel='noreferrer'>
                                         <Button
                                             variant='outline-secondary'
                                             onMouseDown={() => handleDownloadLocal(result)}


### PR DESCRIPTION
During `npm build`, it was complaining about the `noopener` and `noreferrer.`. This is to fix that error and #41 



`Error: Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank`
