### PR TITLE
Re-Add curl to apk add

### DIFF
--- a/alpine-cron/Dockerfile
+++ b/alpine-cron/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine AS builder
 
-RUN apk add --no-cache mongodb-tools py3-pip
+RUN apk add --no-cache curl mongodb-tools py3-pip
 RUN pip install b2
 RUN mkdir /tmp/backups
 


### PR DESCRIPTION
When cleaning up the `Dockerfile` for Alpine Cron, I thought I didn't need `curl`. But I totally do since I curl my own API.

Previous commit https://github.com/hxrsmurf/ytdlp-flask-nextjs/commit/77ce7b75088dbb76f619406ed2a22d7742daaa61