### PR TITLE
Feature/ytdlp bestformat merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docker-compose.yml
 mongodb/restore.txt
 *.ts
 *.webm
+ffmpeg/script.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ alpine-cron/docker-compose.yaml
 docker-compose.yml
 *.sqlite3
 mongodb/restore.txt
+*.ts
+*.webm

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,9 @@
-from python:3.10.5-slim
+FROM python:3.10.5-slim
 
 COPY requirements.txt /
 
 RUN pip3 install -r /requirements.txt
+RUN apt-get update && apt-get install ffmpeg -yf
 
 COPY . /app
 

--- a/backend/functions/downloader.py
+++ b/backend/functions/downloader.py
@@ -15,7 +15,8 @@ def download(video, video_range=2, download_confirm=False):
         'playlistend' : video_range,
         'ignoreerrors' : True,
         'format': 'bestvideo*+bestaudio/best',
-        'merge_output_format': 'mp4'
+        'merge_output_format': 'mp4',
+        'keepvideo' : True
     }
 
     with YoutubeDL(ytdl_opts) as ydl:

--- a/backend/functions/downloader.py
+++ b/backend/functions/downloader.py
@@ -13,7 +13,9 @@ def download(video, video_range=2, download_confirm=False):
         #'download_archive': 'static/downloaded_videos.txt',
         'windowsfilenames': True,
         'playlistend' : video_range,
-        'ignoreerrors' : True
+        'ignoreerrors' : True,
+        'format': 'bestvideo*+bestaudio/best',
+        'merge_output_format': 'mp4'
     }
 
     with YoutubeDL(ytdl_opts) as ydl:

--- a/backend/functions/downloader.py
+++ b/backend/functions/downloader.py
@@ -7,7 +7,7 @@ def download(video, video_range=2, download_confirm=False):
 
     ytdl_opts = {
         #'outtmpl' : 'static/%(uploader)s/%(upload_date>%Y-%m-%d)s_%(id)s_%(title)s.%(ext)s',
-        'outtmpl' : '%(id)s.%(ext)s',
+        'outtmpl' : '%(id)s/%(id)s.%(ext)s',
         'progress_hooks' : [hook],
         #'daterange' : 'today-1year',
         #'download_archive': 'static/downloaded_videos.txt',
@@ -15,8 +15,7 @@ def download(video, video_range=2, download_confirm=False):
         'playlistend' : video_range,
         'ignoreerrors' : True,
         'format': 'bestvideo*+bestaudio/best',
-        'merge_output_format': 'mp4',
-        'keepvideo' : True
+        'merge_output_format': 'mp4'
     }
 
     with YoutubeDL(ytdl_opts) as ydl:

--- a/ffmpeg/script.ps1.example
+++ b/ffmpeg/script.ps1.example
@@ -1,0 +1,28 @@
+# https://hub.docker.com/r/jrottenberg/ffmpeg
+
+# Windows
+docker run -v "C:/ytdlp-flask-nextjs/ffmpeg":/tmp -w /C:/ytdlp-flask-nextjs/ffmpeg jrottenberg/ffmpeg -i https://cdn/video.mp4 -f mp4 /tmp/out.mp4
+
+docker run -v "C:/ytdlp-flask-nextjs/ffmpeg":/tmp -w /C:/ytdlp-flask-nextjs/ffmpeg jrottenberg/ffmpeg -i /tmp/video.mp4 -f mp4 /tmp/tt.mp4
+
+# Linux
+docker run -v $(pwd):$(pwd) -w $(pwd) jrottenberg/ffmpeg -i https://cdn/video.mp4 -f mp4 /tmp/out.mp4
+
+
+$url = "C:/ytdlp-flask-nextjs/ffmpeg/video.mp4"
+$output = $url.split('/')[$url.split('/').length-1]
+$folder = $output.split('.')[0]
+
+# ffmpeg -i in.mkv -c:v copy -flags +cgop -g 30 -hls_time 1 -hls_playlist_type event folder\out.m3u8
+
+docker run -v C:/ytdlp-flask-nextjs/ffmpeg/${folder}:/tmp/${folder} `
+    -w /C:/ytdlp-flask-nextjs/ffmpeg `
+    jrottenberg/ffmpeg `
+    -i $url `
+    -c copy `
+    -flags +cgop `
+    -g 30 `
+    -hls_time 1 `
+    -hls_playlist_type event `
+    /tmp/$folder/$folder.m3u8 `
+    -f mp4 /tmp/$output

--- a/ffmpeg/script.txt
+++ b/ffmpeg/script.txt
@@ -1,9 +1,0 @@
-# https://hub.docker.com/r/jrottenberg/ffmpeg
-
-# Windows
-docker run -v "C:/ytdlp-flask-nextjs/ffmpeg":/tmp -w /C:/ytdlp-flask-nextjs/ffmpeg jrottenberg/ffmpeg -i https://cdn/video.mp4 -f mp4 /tmp/out.mp4
-
-docker run -v "C:/ytdlp-flask-nextjs/ffmpeg":/tmp -w /C:/ytdlp-flask-nextjs/ffmpeg jrottenberg/ffmpeg -i /tmp/video.mp4 -f mp4 /tmp/tt.mp4
-
-# Linux
-docker run -v $(pwd):$(pwd) -w $(pwd) jrottenberg/ffmpeg -i https://cdn/video.mp4 -f mp4 /tmp/out.mp4


### PR DESCRIPTION
I noticed the videos that are downloaded are low quality. The default option for `yt-dlp` is to try its best to get the best quality for video and audio, no conversion required.

I opted to add the below to the options and also add ffmpeg to the Dockerfile.


```
        'format': 'bestvideo*+bestaudio/best',
        'merge_output_format': 'mp4'
```
I may switch to the ffmpeg docker container and then install python on it, I'm not sure.