### PR TITLE
Feature - Add Backblaze Sync functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ alpine-cron/docker-compose.yaml
 docker-compose.yml
 *.sqlite3
 mongodb/restore.txt
+*.webm

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -333,7 +333,7 @@ def download_video_by_id(video_id):
 
     video_file_name = f'{video_id}.mp4'
     video_folder = 'videos'
-    cdn_video_url = f'{os.environ.get("CDN_URL")}/{os.environ.get("B2_BUCKET")}/{video_folder}/{video_file_name}'
+    cdn_video_url = f'{os.environ.get("CDN_URL")}/{os.environ.get("B2_BUCKET")}/{video_folder}/{video_id}/{video_file_name}'
 
     try:
         query_cdn_video_url = query_json['cdn_video']

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -3,6 +3,7 @@ import os
 import requests
 import concurrent.futures
 from flask import Blueprint, jsonify, request, Response
+import shutil
 
 from functions.downloader import download
 from functions.utils import getCurrentTime
@@ -361,6 +362,6 @@ def download_video_by_id(video_id):
         print('Complete Database Update')
 
         if os.path.exists(video_file_name):
-            os.remove(video_file_name)
+            shutil.rmtree(video_file_name)
 
         return(cdn_video_url)

--- a/backend/functions/backblaze_upload.py
+++ b/backend/functions/backblaze_upload.py
@@ -1,21 +1,24 @@
 import os
+import sys
+import time
+
 from dotenv import load_dotenv
 
 from b2sdk.v2 import *
 
 load_dotenv('../.env')
 
+B2_BUCKET = os.environ.get("B2_BUCKET")
+B2_KEY_ID = os.environ.get("B2_KEY_ID")
+B2_KEY = os.environ.get("B2_KEY")
+
+info = InMemoryAccountInfo()
+b2_api = B2Api(info)
+b2_api.authorize_account("production", B2_KEY_ID, B2_KEY)
+bucket = b2_api.get_bucket_by_name(B2_BUCKET)
+
 def b2_upload(file, folder):
-    B2_BUCKET = os.environ.get("B2_BUCKET")
-    B2_KEY_ID = os.environ.get("B2_KEY_ID")
-    B2_KEY = os.environ.get("B2_KEY")
-
     b2_destination = f'{folder}/{file}'
-
-    info = InMemoryAccountInfo()
-    b2_api = B2Api(info)
-    b2_api.authorize_account("production", B2_KEY_ID, B2_KEY)
-    bucket = b2_api.get_bucket_by_name(B2_BUCKET)
     print('Uploading to BackBlaze')
     result = bucket.upload_local_file(
             local_file=file,
@@ -23,3 +26,23 @@ def b2_upload(file, folder):
         )
     print('Successfully uploaded to BackBlaze')
     return(result)
+
+def b2_sync(video_id):
+    # https://b2-sdk-python.readthedocs.io/en/master/api/sync.html
+    source_folder = parse_sync_folder(f'{video_id}', b2_api)
+    destination_folder = parse_sync_folder(f'b2://{B2_BUCKET}/videos/{video_id}', b2_api)
+
+    synchronizer = Synchronizer( max_workers=100, dry_run=False )
+    no_progress = False
+    try:
+        with SyncReport(sys.stdout, no_progress) as reporter:
+            synchronizer.sync_folders(
+                source_folder=source_folder,
+                dest_folder=destination_folder,
+                now_millis=int(round(time.time() * 1000)),
+                reporter=reporter
+            )
+        return('Success')
+    except Exception as e:
+        print(e)
+        return('Failure')

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  images: { domains: ['cdn', 'i.ytimg.com']}
+  images: { domains: ['cdn-youtube.kvchmurphy.com', 'i.ytimg.com']}
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
In preparation to convert the `mp4` to `hls` for better streaming, I wanted to be able to:

1. Download the video to its own folder
2. Convert mp4 to HLS
3. Keep all files
4. Upload to Backblaze
    - Easier to do `sync` versus `copy_file`
6. Delete all downloaded files