### PR TITLE
Feature/clear database of cdn_video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ mongodb/restore.txt
 *.ts
 *.webm
 ffmpeg/script.ps1
+powershell/delete-b2-files.ps1

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -345,6 +345,7 @@ def download_video_by_id(video_id):
             print(f'Database is out of date. Updating...')
             Mongo.Videos.objects(video_id=video_id).update_one(set__cdn_video=cdn_video_url)
             print('Complete Database Update')
+        return(f'{video_id} exists on CDN')
     else:
         print(f'Downloading {video_id}')
         download_result = download(video=original_url, video_range=1, download_confirm=True)
@@ -365,3 +366,11 @@ def download_video_by_id(video_id):
             shutil.rmtree(video_file_name)
 
         return(cdn_video_url)
+
+@mongo_bp.route('/database/clear/cdn/videos')
+def clear_cdn_videos():
+    videos = videos_already_downloaded()
+    for video in json.loads(videos.data):
+        video_id = video['_id']
+        Mongo.Videos.objects(video_id=video_id).update_one(set__cdn_video=None)
+    return(videos)

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -370,7 +370,14 @@ def download_video_by_id(video_id):
 @mongo_bp.route('/database/clear/cdn/videos')
 def clear_cdn_videos():
     videos = videos_already_downloaded()
-    for video in json.loads(videos.data):
-        video_id = video['_id']
-        Mongo.Videos.objects(video_id=video_id).update_one(set__cdn_video=None)
-    return(videos)
+    try:
+        confirm = request.args['confirm']
+        if confirm == 'true':
+            for video in json.loads(videos.data):
+                video_id = video['_id']
+                Mongo.Videos.objects(video_id=video_id).update_one(set__cdn_video=None)
+            return('Database cleared')
+        else:
+            return('<a href="?confirm=true">Click this to confirm deletion</a>')
+    except:
+        return(videos)

--- a/powershell/delete-b2-files.ps1.example
+++ b/powershell/delete-b2-files.ps1.example
@@ -1,0 +1,7 @@
+$bucket = 'bucket'
+$files = b2 ls $bucket videos
+
+yt-dlp [videoID] -f bestvideo*+bestaudio/best --merge-output-format mp4
+
+b2 sync --dryRun --delete --allowEmptySource . b2://$bucket/videos/
+b2 ls $bucket videos/


### PR DESCRIPTION
In https://github.com/hxrsmurf/ytdlp-flask-nextjs/pull/53, I updated to use B2 Sync as well as sub-folder with the video id. 

I needed a quick way to clear out the database of `cdn_video` and Backblaze bucket.

I added a double-confirmation (sort of) to make sure I want to proceed.

