### PR TITLE
Add misc. scripts for DigitalOcean integration

### DIFF
--- a/digitalocean/bunny.sh
+++ b/digitalocean/bunny.sh
@@ -1,0 +1,25 @@
+curl --request POST \
+     --url https://video.bunnycdn.com/library/VIDEOLIBRARYID/videos \
+     --header 'Accept: application/json' \
+     --header 'AccessKey: ACCESSKEY' \
+     --header 'Content-Type: application/*+json' \
+     --data '{"title":"555555555555555"}'
+
+curl -vv --request PUT \
+     --url 'https://video.bunnycdn.com/library/VIDEOLIBRARYID/videos/VIDEOID?enabledResolutions=1080' \
+     --header 'Accept: application/json' \
+     --header 'AccessKey: ACCESSKEY' \
+     --data-binary '@VIDEOID.mp4'
+
+curl --request GET \
+     --url 'https://video.bunnycdn.com/library/VIDEOLIBRARYID/videos/VIDEOID' \
+     --header 'Accept: application/json' \
+     --header 'AccessKey: ACCESSKEY' \
+
+$headers=@{}
+$headers.Add("Accept", "application/json")
+$headers.Add("AccessKey", "ACCESSKEY")
+$response = Invoke-WebRequest -Uri 'https://video.bunnycdn.com/library/VIDEOLIBRARYID/videos/VIDEOID?enabledResolutions=1080' -Method PUT -Headers $headers -InFile 'IlF3oFqVt1c.mp4'
+
+
+curl --request PUT --url 'https://video.bunnycdn.com/library/VIDEOLIBRARYID/videos/VIDEOID?enabledResolutions=1080' --header 'Accept: application/json' --header 'AccessKey: ACCESSKEY' --data-binary 'VIDEOID.mp4'

--- a/digitalocean/curl-works.sh
+++ b/digitalocean/curl-works.sh
@@ -1,0 +1,12 @@
+curl --request POST \
+     --url https://video.bunnycdn.com/library/LIBRARYID/videos \
+     --header 'Accept: application/json' \
+     --header 'AccessKey: ACCESSKEY' \
+     --header 'Content-Type: application/*+json' \
+     --data '{"title":"python"}'
+
+curl --location --request PUT 'https://video.bunnycdn.com/library/LIBRARYID/videos/VIDEOID' \
+--header 'Accept: application/json' \
+--header 'Content-Type: application/json' \
+--header 'AccessKey: ACCESSKEY' \
+--data-binary '@VIDEOID.mp4'

--- a/digitalocean/python-works.py
+++ b/digitalocean/python-works.py
@@ -1,0 +1,30 @@
+import requests
+import json
+
+library = 'LIBRARYID'
+
+url = "https://video.bunnycdn.com/library/LIBRARYID/videos"
+
+payload = "{\"title\":\"test\"}"
+headers = {
+    "Accept": "application/json",
+    "Content-Type": "application/*+json",
+    "AccessKey": "ACCESSKEY"
+}
+
+response = requests.post(url, data=payload, headers=headers)
+
+guid = json.loads(response.text)['guid']
+print(guid)
+
+
+file = open('VIDEOID.mp4','rb')
+video_url = f'https://video.bunnycdn.com/library/LIBRARYID/videos/{guid}'
+print(video_url)
+headers = {
+    "Accept": "application/json",
+    "AccessKey": "ACCESSKEY",
+}
+response = requests.put(video_url, headers=headers, data=file)
+
+print(response)

--- a/digitalocean/script.sh
+++ b/digitalocean/script.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+yt-dlp --format bestvideo*+bestaudio/best --merge-output-format mp4 --output '%(id)s/%(id)s.%(ext)s' https://youtu.be/VIDEOID
+
+yt-dlp --format bestvideo*+bestaudio/best --merge-output-format mp4 --output '%(id)s/%(id)s.%(ext)s' https://youtu.be/VIDEOID
+
+#!/bin/bash
+apt-get update
+#apt-get install python pip ffmpeg docker.io -yf
+apt-get install python pip ffmpeg -yf
+pip install yt-dlp
+cd /root/
+yt-dlp --format bestvideo*+bestaudio/best --merge-output-format mp4 --output '%(id)s/%(id)s.%(ext)s' https://youtu.be/VIDEOID
+cd VIDEOID
+ffmpeg -i VIDEOID.mp4 \
+    -c:v libx264 \
+    -c:a copy \
+    -flags +cgop \
+    -g 30 \
+    -hls_time 1 \
+    -hls_playlist_type event \
+    VIDEOID.m3u8
+
+#!/bin/bash
+apt-get update
+apt-get install docker-compose git -yf
+git clone https://github.com/hxrsmurf/ytdlp-flask-nextjs
+docker pull python:3.10.5-slim
+docker pull mongo
+docker pull mongo-express
+cd ytdlp-flask-nextjs/backend
+docker-compose --build
+
+cd ytdlp-flask-nextjs/mongodb
+docker-compose up --build -d
+cd ytdlp-flask-nextjs/backend
+docker-compose up --build
+
+ffmpeg -i VIDEOID.mp4 \
+    -c copy \
+    -flags +cgop \
+    -g 30 \
+    -hls_time 1 \
+    -hls_playlist_type event \
+    VIDEOID.m3u8
+
+docker run -v $(pwd):$(pwd) \
+    -w $(pwd) \
+    jrottenberg/ffmpeg \
+    -i VIDEOID.mp4 \
+    -c copy \
+    -flags +cgop \
+    -g 30 \
+    -hls_time 1 \
+    -hls_playlist_type event \
+    VIDEOID.m3u8
+
+    #######


### PR DESCRIPTION
I started down the path of using DigitalOcean droplets to:

1. Download the YouTube video
2. Merge the YouTube video with `ffmpeg`
3. 4. Convert MP4 to HLS with `ffmpeg`
4. 5. Upload to BackBlaze 

But I found most of the YouTube (merged) videos are VP9 codec which `HLS` does not love and would need to be converted to `libx264`. 

The Droplets were way too slow to convert that and I'd be charged for an hour at a time.

Therefore, I'm investigating other conversion tools. I'll eventually add self-hosted functionality #69 . For now just basic HLS support #66 