### PR TITLE
Update EntryForm.js Else to use Channels Backend URL

### DIFF
--- a/frontend/Components/EntryForm.js
+++ b/frontend/Components/EntryForm.js
@@ -20,7 +20,7 @@ export default function EntryForm() {
             setTimeout(() => setLoading(false), 1000)
         }
         else {
-            await fetch(base_api + '/mongo/videos/add?url=' + value)
+            await fetch(base_api + '/mongo/channels/add?url=' + value)
         }
 
         setLoading(false)


### PR DESCRIPTION
The EntryForm.js had an `else` statement that defaulted to `videos`. I updated this to `channels`.

Since most / all videos would actually be videos. Some technical debt, I suppose.
