### PR TITLE
Feature - DigitalOcean UserData and Bash Script to Download and Upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ powershell/delete-b2-files.ps1
 aws/lambda/.aws-sam/*
 aws/lambda-ec2/.aws-sam/*
 standalone/config.json
+digitalocean/docker.sh

--- a/digitalocean/docker.sh.example
+++ b/digitalocean/docker.sh.example
@@ -1,0 +1,7 @@
+#!/bin/bash
+B2_BUCKET=
+B2_KEY_ID=
+B2_KEY=
+
+docker run --rm -v /tmp:/media:Z tnk4on/yt-dlp --format bestvideo*+bestaudio/best --merge-output-format mp4 --output '%(id)s/%(id)s.%(ext)s' $1
+docker run --rm -v /tmp:/root -e B2_APPLICATION_KEY_ID=$B2_KEY_ID -e B2_APPLICATION_KEY=$B2_KEY sierra1011/backblaze-b2 sync /root/$2 b2://$B2_BUCKET/videos/$2

--- a/digitalocean/userdata.txt
+++ b/digitalocean/userdata.txt
@@ -1,0 +1,6 @@
+#!/bin/bash
+apt-get update
+apt-get install git docker.io python3-pip ffmpeg -yf
+pip install yt-dlp
+pip3 install -r ytdlp-flask-nextjs/standalone/requirements.txt
+git clone https://github.com/hxrsmurf/ytdlp-flask-nextjs.git

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -93,9 +93,12 @@ def parse_config():
     return json.loads(file_data)
 
 if __name__ == "__main__":
-    FEATURE_DOWNLOAD = False
+    FEATURE_DOWNLOAD, isWindowsOS = True, False
     config = parse_config()
     API_URL = config['API_URL']
+
+    if os.name == 'nt':
+        isWindowsOS = True
 
     if not len(sys.argv) == 1:
         video_id = sys.argv[1]
@@ -116,7 +119,11 @@ if __name__ == "__main__":
             channel_name = video['channel_name']
             thumbnail_url = video['thumbnail']
 
-            if 'HelloWorld' in channel_name and FEATURE_DOWNLOAD:
-                subprocess.call(['./script.sh',original_url,video_id])
-                if os.path.exists(f'/tmp/{video_id}'):
-                    shutil.rmtree(f'/tmp/{video_id}')
+            if 'HBO' in channel_name and FEATURE_DOWNLOAD:
+                print(channel_name)
+                if not isWindowsOS:
+                    subprocess.call(['./docker.sh',original_url,video_id])
+                    if os.path.exists(f'/tmp/{video_id}'):
+                        shutil.rmtree(f'/tmp/{video_id}')
+                elif isWindowsOS:
+                    download(video=original_url,video_range=1, download_confirm=True)

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import os
 import requests
+import shutil
+import subprocess
 import sys
 
 from ffmpeg import FFmpeg
@@ -115,9 +117,6 @@ if __name__ == "__main__":
             thumbnail_url = video['thumbnail']
 
             if 'HelloWorld' in channel_name and FEATURE_DOWNLOAD:
-                if not os.path.exists(f'{video_id}/{video_id}.webp'):
-                    download_thumbnail(thumbnail_url=thumbnail_url,video_id=video_id)
-
-                if not os.path.exists(video_id):
-                    download(video=original_url, video_range=1, download_confirm=True)
-                    convert_to_hls(video_id=video_id)
+                subprocess.call(['./script.sh',original_url,video_id])
+                if os.path.exists(f'/tmp/{video_id}'):
+                    shutil.rmtree(f'/tmp/{video_id}')

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -96,6 +96,7 @@ if __name__ == "__main__":
     FEATURE_DOWNLOAD, isWindowsOS = True, False
     config = parse_config()
     API_URL = config['API_URL']
+    CDN_URL = config['CDN_URL']
 
     if os.name == 'nt':
         isWindowsOS = True
@@ -121,9 +122,12 @@ if __name__ == "__main__":
 
             if 'HBO' in channel_name and FEATURE_DOWNLOAD:
                 print(channel_name)
-                if not isWindowsOS:
-                    subprocess.call(['./docker.sh',original_url,video_id])
-                    if os.path.exists(f'/tmp/{video_id}'):
-                        shutil.rmtree(f'/tmp/{video_id}')
-                elif isWindowsOS:
-                    download(video=original_url,video_range=1, download_confirm=True)
+                check_exists_cdn = requests.head(f'{CDN_URL}/{video_id}/{video_id}.mp4')
+                print(f'{video_id} - {check_exists_cdn}')
+                if not check_exists_cdn.status_code == 200:
+                    if not isWindowsOS:
+                        subprocess.call(['./docker.sh',original_url,video_id])
+                        if os.path.exists(f'/tmp/{video_id}'):
+                            shutil.rmtree(f'/tmp/{video_id}')
+                    elif isWindowsOS:
+                        download(video=original_url,video_range=1, download_confirm=True)


### PR DESCRIPTION
The smallest `Droplet` at [DigitalOcean](https://www.digitalocean.com/pricing/droplets) includes 500GiB of outbound transfer and can easily download and upload files. Its cost is $0.06 per hour. 

The work I did previously for testing docker and the right commands came in handy.

I think I'll use DigitalOcean to download/upload videos.

The existing HTTP 200 checks in mongo.py should update the database, in theory. https://github.com/hxrsmurf/ytdlp-flask-nextjs/blob/655f207fb87a3aca05de33146188349d474bb875/backend/blueprints/mongo.py#L355
