### PR TITLE
Feature - Use Redis Lists Instead of Pub/Sub for Queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ digitalocean/docker.sh
 standalone/docker.sh
 redis/__pycache__/*
 redis/subscriber_docker/__pycache__/*
+redis/lists/__pycache__/*

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,6 @@ VIDEO_ID_TO_USE=example
 AWS_API_URL=example
 COUNT_VIDEOS_TO_LOAD=example
 example_URL=/mongo/download/video/videoid
+
+REDIS_CHANNEL_NAME=example
+REDIS_SERVER=127.0.0.1

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -334,8 +334,6 @@ def download_video_by_id(video_id):
     video_title = query_json['title']
     duration = query_json['duration']
 
-    redis_add_to_list(video_id=video_id, video_url=original_url, duration=duration)
-
     cdn_mp4_exists, cdn_mp4_db, cdn_hls_exists, cdn_hls_db, check_cdn_mp4 = False,False, False, False, False
 
     if 'cdn_video' in query_json.keys():
@@ -394,7 +392,7 @@ def download_video_by_id(video_id):
                     return(message)
                 else:
                     message = f'Queueing {video_id} - {original_url}'
-                    redis_publish(video_id=video_id, video_url=original_url, duration=duration)
+                    redis_add_to_list(video_id=video_id, video_url=original_url, duration=duration)
                     return(message)
                     if not FEATURE_REDIS:
                         Mongo.DownloadQueue(

--- a/backend/blueprints/mongo.py
+++ b/backend/blueprints/mongo.py
@@ -10,7 +10,7 @@ from functions.downloader import download
 from functions.utils import getCurrentTime, getInitialVideosToLoad
 from functions.backblaze_upload import b2_upload, b2_sync
 from functions.convert_ffmpeg import convert_to_hls
-from functions.utils import redis_publish
+from functions.utils import redis_publish, redis_add_to_list
 
 from functions.bunnycdn import *
 
@@ -333,6 +333,8 @@ def download_video_by_id(video_id):
     original_url = query_json['original_url']
     video_title = query_json['title']
     duration = query_json['duration']
+
+    redis_add_to_list(video_id=video_id, video_url=original_url, duration=duration)
 
     cdn_mp4_exists, cdn_mp4_db, cdn_hls_exists, cdn_hls_db, check_cdn_mp4 = False,False, False, False, False
 

--- a/backend/functions/utils.py
+++ b/backend/functions/utils.py
@@ -23,3 +23,18 @@ def redis_publish(video_id, video_url, duration):
     message = str({'video_url': video_url, 'video_id': video_id, 'duration': duration})
     redis_db.publish(redis_channel, message)
     return(message)
+
+def redis_add_to_list(video_id, video_url, duration):
+    redis_db = redis.Redis(
+        host=os.environ.get('REDIS_SERVER'),
+        port='6379',
+        decode_responses=True
+    )
+
+    redis_channel = os.environ.get('REDIS_CHANNEL_NAME')
+
+    message = str({'video_url': video_url, 'video_id': video_id, 'duration': duration})
+    try:
+        print(redis_db.rpush(redis_channel, message))
+    except Exception as e:
+        print(e)

--- a/redis/lists/lists.py
+++ b/redis/lists/lists.py
@@ -1,0 +1,10 @@
+from shared import redis_db
+
+redis_queue_name = 'download_queue'
+
+while True:
+    message = redis_db().blpop(redis_queue_name, 30)
+    if not message:
+        continue
+    else:
+        print(message)

--- a/redis/lists/shared.py
+++ b/redis/lists/shared.py
@@ -1,0 +1,7 @@
+import redis
+
+def redis_db():
+    return redis.Redis(
+        host='127.0.0.1',
+        port='6379'
+    )

--- a/redis/lists/view_list.py
+++ b/redis/lists/view_list.py
@@ -2,8 +2,8 @@ import time
 
 from shared import redis_db
 
-redis_queue_name = 'download_queue'
+redis_queue_name = 'download-queue'
 
 while True:
     print(redis_db().lrange(redis_queue_name, 0, -1))
-    time.sleep(10)
+    time.sleep(2)

--- a/redis/lists/view_list.py
+++ b/redis/lists/view_list.py
@@ -1,0 +1,9 @@
+import time
+
+from shared import redis_db
+
+redis_queue_name = 'download_queue'
+
+while True:
+    print(redis_db().lrange(redis_queue_name, 0, -1))
+    time.sleep(10)

--- a/standalone/ReadMe.md
+++ b/standalone/ReadMe.md
@@ -2,6 +2,9 @@ Run standalone.py to open a listener which `blop` the `REDIS_QUEUE_NAME`
 
 Depending on video duration, process local or process on AWS.
 
+
+# My Setup
+
 Locally
 - Flask Backend
 - NextJS Frontend

--- a/standalone/ReadMe.md
+++ b/standalone/ReadMe.md
@@ -1,0 +1,11 @@
+Run standalone.py to open a listener which `blop` the `REDIS_QUEUE_NAME`
+
+Depending on video duration, process local or process on AWS.
+
+Locally
+- Flask Backend
+- NextJS Frontend
+- Redis server (storage is NOT saved)
+
+DigitalOcean:
+- standalone.py in `screen` session

--- a/standalone/config.json.example
+++ b/standalone/config.json.example
@@ -11,5 +11,7 @@
     "BUNNYCDN_URL": "example",
     "VIDEO_ID_TO_USE": "example",
     "AWS_API_URL": "example"
-    "REDIS_URL": "example"
+    "REDIS_URL": "example",
+    "REDIS_QUEUE_NAME": "example",
+    "RUNNING_LOCAL": [true | false]
 }

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -147,7 +147,7 @@ def redis_subscriber():
 def redis_get_list():
     redis_db = redis.Redis(host=config['REDIS_URL'], port='6379', decode_responses=True)
     while True:
-        message = redis_db.blpop([config['REDIS_QUEUE_NAME']],30)
+        message = redis_db.blpop([config['REDIS_QUEUE_NAME']],120)
         if not message:
             continue
         else:

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -147,7 +147,10 @@ def redis_subscriber():
 if __name__ == "__main__":
     FEATURE_DOWNLOAD, isWindowsOS, FEATURE_AWS_PROCESSING, RUNNING_LOCAL = True, False, False, True
     config = parse_config()
-    API_URL = config['LOCAL_API_URL']
+    if RUNNING_LOCAL:
+        API_URL = config['LOCAL_API_URL']
+    else:
+        API_URL = config['API_URL']
     CDN_URL = config['CDN_URL']
     AWS_API_URL = config['AWS_API_URL']
 


### PR DESCRIPTION
#58 

I wanted to switch from pub/sub to FIFO queue. This would allow me to add additional servers to process.

For example, I could have another local server listen and DigitalOcean. In case I queued up a bunch of videos, it'd process them faster.

