### PR TITLE
Hotfix - Fix Improper Redis Caching for Videos and Channels

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,6 @@ VIDEO_ID_TO_USE=example
 AWS_API_URL=example
 COUNT_VIDEOS_TO_LOAD=example
 example_URL=/mongo/download/video/videoid
-
 REDIS_CHANNEL_NAME=example
 REDIS_SERVER=127.0.0.1
+REDIS_CACHE_LENGTH=300

--- a/backend/functions/utils.py
+++ b/backend/functions/utils.py
@@ -47,7 +47,7 @@ def redis_cache_videos(data=None):
     cached_videos = redis_db.get('videos')
     if cached_videos == 'None' or cached_videos == None:
         redis_db.set('videos', str(data))
-        redis_db.expire('videos',600)
+        redis_db.expire('videos',os.environ.get('REDIS_CACHE_LENGTH'))
         cached_videos = redis_db.get('videos')
         return(ast.literal_eval(cached_videos))
     else:
@@ -57,7 +57,7 @@ def redis_cache_channels(data=None):
     cached_channels = redis_db.get('channels')
     if cached_channels == 'None' or cached_channels == None:
         redis_db.set('channels', str(data))
-        redis_db.expire('channels', 600)
+        redis_db.expire('channels', os.environ.get('REDIS_CACHE_LENGTH'))
         cached_channels = redis_db.get('channels')
         return(ast.literal_eval(cached_channels))
     else:
@@ -68,7 +68,7 @@ def redis_cache_channels_unique(data=None):
     if cached_channels_unique == 'None' or cached_channels_unique == None:
         print("go cache")
         redis_db.set('channels_unique', str(data))
-        redis_db.expire('channels_unique', 5)
+        redis_db.expire('channels_unique', os.environ.get('REDIS_CACHE_LENGTH'))
         cached_channels_unique = redis_db.get('channels_unique')
         return(ast.literal_eval(cached_channels_unique))
     else:

--- a/backend/functions/utils.py
+++ b/backend/functions/utils.py
@@ -44,22 +44,23 @@ def redis_add_to_list(video_id, video_url, duration):
 
 
 def redis_cache_videos(data=None):
-    if not redis_db.get('videos'):
+    cached_videos = redis_db.get('videos')
+    if cached_videos == 'None' or cached_videos == None:
         redis_db.set('videos', str(data))
         redis_db.expire('videos',600)
-        return None
+        cached_videos = redis_db.get('videos')
+        return(ast.literal_eval(cached_videos))
     else:
-        result = redis_db.get('videos')
-        return(ast.literal_eval(result))
+        return(ast.literal_eval(cached_videos))
 
 def redis_cache_channels(data=None):
     cached_channels = redis_db.get('channels')
-    if cached_channels:
-        return(ast.literal_eval(cached_channels))
-    else:
+    if cached_channels == 'None' or cached_channels == None:
         redis_db.set('channels', str(data))
         redis_db.expire('channels', 600)
         cached_channels = redis_db.get('channels')
+        return(ast.literal_eval(cached_channels))
+    else:
         return(ast.literal_eval(cached_channels))
 
 def redis_cache_channels_unique(data=None):


### PR DESCRIPTION
#118 

The videos and channels didn't properly cache/retrieve results.

With #132 I found a `better` way to do it.