### PR TITLE
Fix Template, Update SQS Parser, Update Requests Layer

### DIFF
--- a/aws/yt-dlp/sqs-parser/functions/parse.py
+++ b/aws/yt-dlp/sqs-parser/functions/parse.py
@@ -31,4 +31,4 @@ def parse_channel_info(info):
         'webpage_url_basename' : json_info['webpage_url_basename']
     }
 
-    return json.dumps(output_info), video_id
+    return json.dumps(output_info), video_id, video_original_url

--- a/aws/yt-dlp/sqs-parser/functions/parse.py
+++ b/aws/yt-dlp/sqs-parser/functions/parse.py
@@ -5,6 +5,7 @@ def parse_channel_info(info):
     logging.info('Parsing info...')
     json_info = json.loads(info)
     video_id = json_info['entries'][0]['entries'][0]['id']
+    video_original_url = json_info['entries'][0]['entries'][0]['original_url']
 
     output_info = {
         'id' : json_info['id'],
@@ -23,7 +24,7 @@ def parse_channel_info(info):
         # First Entry of Channel's Video
         'video_id': video_id,
         'video_webpage_url': json_info['entries'][0]['entries'][0]['webpage_url'],
-        'video_original_url': json_info['entries'][0]['entries'][0]['original_url'],
+        'video_original_url': video_original_url,
 
         'webpage_url' : json_info['webpage_url'],
         'original_url' : json_info['original_url'],

--- a/aws/yt-dlp/sqs-parser/index.py
+++ b/aws/yt-dlp/sqs-parser/index.py
@@ -17,6 +17,8 @@ def handler(event, context):
         base_url = os.environ['ApiUrl']
         url = f'{base_url}/download?url={video_original_url}'
         requests.get(url)
+    else:
+        logging.info(f'Already exists: {url}')
 
     return({
             'statusCode': 200,

--- a/aws/yt-dlp/template.yaml
+++ b/aws/yt-dlp/template.yaml
@@ -2,6 +2,11 @@ Transform: AWS::Serverless-2016-10-31
 
 Description: NextJS-13 YouTube-DLP
 
+Parameters:
+  ApiUrl:
+    Type: String
+    Default: http://placeholder.homelabwithkevin.com:8080
+
 Resources:
   Queue:
     Type: AWS::SQS::Queue
@@ -12,11 +17,6 @@ Resources:
     Type: AWS::Serverless::SimpleTable
     Properties:
       TableName: nextjs-13-yt-dlp-channels
-
-  ApiUrl:
-    Type: String
-    Properties:
-      Default: http://placeholder.homelabwithkevin.com:8080
 
   Lambda:
     Type: 'AWS::Serverless::Function'
@@ -49,8 +49,8 @@ Resources:
     Properties:
       Handler: index.handler
       Runtime: python3.9
-      CodeUri: python
-      MemorySize: 256
+      CodeUri: sqs-parser
+      MemorySize: 512
       Timeout: 60
       Environment:
         Variables:
@@ -59,7 +59,7 @@ Resources:
           ApiUrl: !Ref ApiUrl
       Layers:
         - !Ref Layer
-        - !Ref ffmpeg
+        - !Ref requests
       Events:
         SQS:
           Type: SQS


### PR DESCRIPTION
The `template.yaml` had a bug in it in which I was passing a Parameter as a resource. This caused the ChangeSet to fail.

I updated `SQS Parser` to query my Flask/Celery backend to download the video.